### PR TITLE
Fix -f logs to stop when a container exits

### DIFF
--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -83,7 +83,11 @@ func (c *Container) readFromLogFile(options *logs.LogOptions, logChannel chan *l
 					break
 				}
 				if state != define.ContainerStateRunning && state != define.ContainerStatePaused {
-					t.StopAtEOF()
+					err := t.Stop()
+					if err != nil {
+						logrus.Error(err)
+						break
+					}
 					break
 				}
 				time.Sleep(1 * time.Second)

--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -88,7 +88,6 @@ func (c *Container) readFromLogFile(options *logs.LogOptions, logChannel chan *l
 					err := t.Stop()
 					if err != nil {
 						logrus.Error(err)
-						break
 					}
 					break
 				}

--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -78,8 +78,10 @@ func (c *Container) readFromLogFile(options *logs.LogOptions, logChannel chan *l
 		if options.Follow {
 			for {
 				state, err := c.State()
-				if err != nil {
+				if err != nil && errors.Cause(err) != define.ErrNoSuchCtr {
 					logrus.Error(err)
+					break
+				} else if err != nil {
 					break
 				}
 				if state != define.ContainerStateRunning && state != define.ContainerStatePaused {


### PR DESCRIPTION
Fixes an issue with the previous PR where a container would exit while following logs and the log tail continued to follow. This creates a subroutine which checks the state of the container and instructs the tailLog to stop when it reaches EOF.

Tested the following conditions:
* Tail and follow logs of running container
* Tail and follow logs of stopped container
* Tail and follow logs of running container which exits after some time